### PR TITLE
Write logs to dedicated CloudWatch log group

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -2,5 +2,5 @@
 
 set -e, -u, -o pipefail
 
-log_group_name=$( jq -r '.syslog.logging.log_group_name' <<< "${LOGGING_TERRAFORM_OUTPUTS}" )
+log_group_name=$( jq -r '.syslog.logging.syslog_log_group_name' <<< "${LOGGING_TERRAFORM_OUTPUTS}" )
 docker build -t docker_syslog ./docker --build-arg log_group_name=$log_group_name


### PR DESCRIPTION
Don't combine with Vector server logs.
Pull correct log group name from SSM terraform outputs.