### PR TITLE
Replace Vector with FluentBit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ version: "3.8"
 services:
   vector:
     build:
-      context: ./docker 
+      context: ./docker
       args:
         log_group_name: "fakegroupname"
-        config_file: "vector.development.toml"
-    ports: 
+        config_file: "fluent-bit.conf"
+    ports:
       - "5002:5002"
   syslog_client:
     build: ./syslog_client

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,11 @@
-FROM timberio/vector:latest-alpine
+FROM amazon/aws-for-fluent-bit
 
 ARG log_group_name
-ARG config_file=vector.toml
+ARG config_file=fluent-bit.conf
 ENV LOG_GROUP_NAME=${log_group_name}
-ENV LOG=debug
 
-COPY ${config_file} /etc/vector/vector.toml
+COPY ${config_file} /fluent-bit/etc/fluent-bit.conf
 
-RUN sed -i "s/<AWS_LOG_GROUP_NAME>/$LOG_GROUP_NAME/g" /etc/vector/vector.toml
-
-RUN cat /etc/vector/vector.toml
+RUN sed -i "s/<AWS_LOG_GROUP_NAME>/$LOG_GROUP_NAME/g" /fluent-bit/etc/fluent-bit.conf
 
 EXPOSE 514/udp


### PR DESCRIPTION
These two services are very much the same in that they convert Syslog to
Cloudwatch logs.

Vector has an open Issue that's causing an error on our side.
https://github.com/timberio/vector/issues/3707